### PR TITLE
Fix cannot build in Xcode 12

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -241,6 +241,8 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     block(s == .authorized)
                 }
             }
+		default:
+			break
         }
     }
     


### PR DESCRIPTION
## Problem
YPImagePicker cannot build in Xcode 12

## Solution
Add the default case in switch block